### PR TITLE
Move Identus to Singleton with Configuration

### DIFF
--- a/FlightTix/FlightTix/Agent/Identus.swift
+++ b/FlightTix/FlightTix/Agent/Identus.swift
@@ -12,6 +12,7 @@ import KeychainSwift
 
 final class Identus: ObservableObject {
     
+    // Exception Types
     final class SeedFailedToSaveToKeychainError: Error {}
     final class SeedKeychainKeyNotPresentError: Error {}
     final class SeedFailedToDeleteFromKeychainError: Error {}
@@ -21,22 +22,36 @@ final class Identus: ObservableObject {
     let mediatorDID: DID
     let seedKeychainKey: String
     let cloudAgentConnectionIdKeychainKey: String
+    let cloudAgentConnectionLabel: String
     let urlSessionConfig: URLSessionConfig
     
-    @Published var agentRunning = false
-    
-    //private var edgeAgent: EdgeAgent
+    // DIDComm Agent
     private var didCommAgent: DIDCommAgent?
+    
+    // Observable Properties
     @Published var status: String = ""
     @Published var error: String?
     
+    // Combine
     private var cancellables = Set<AnyCancellable>()
     
-    init(config: IdentusConfig) throws {
+    // Singleton Configuration
+    private static var config: IdentusConfig?
+    class func setup(_ config: IdentusConfig){
+        Identus.config = config
+    }
+    
+    // Singleton Init with Configuration
+    static var shared: Identus = Identus(config: IdentusConfig())
+    private init(config: IdentusConfig) {
+        
+        guard let config = Identus.config else { fatalError("Identus config not set. Must call Identus.setup(IdentusConfig()) before first use.") }
+        
         mediatorOOBURL = URL(string: config.mediatorOOBString)!
         mediatorDID = try! DID(string: config.mediatorDidString)
         seedKeychainKey = config.seedKeychainKey
         cloudAgentConnectionIdKeychainKey = config.cloudAgentConnectionIdKeychainKey
+        cloudAgentConnectionLabel = config.cloudAgentConnectionLabel
         urlSessionConfig = config.urlSessionConfig
     }
     

--- a/FlightTix/FlightTix/ContentView.swift
+++ b/FlightTix/FlightTix/ContentView.swift
@@ -48,24 +48,24 @@ struct ContentView: View {
                     // Initialize Identus, if we fail to initialize, throw error
                     Task {
                         do {
-                            let identus = try Identus(config: IdentusConfig())
-                            //try await identus.tearDown()
-                            try await identus.start()
-                            identus.startMessageStream()
+                            Identus.setup(IdentusConfig()) // must call Identus.setup(IdentusConfig()) before first use
+                            //try await Identus.shared.tearDown()
+                            try await Identus.shared.start()
+                            Identus.shared.startMessageStream()
                             
-                            if try await !identus.connectionExists(connectionId: "",
-                                                                   label: IdentusConfig().cloudAgentConnectionLabel) {
+                            if try await !Identus.shared.connectionExists(connectionId: "",
+                                                                          label: Identus.shared.cloudAgentConnectionLabel) {
                                 do {
-                                    let invitationFromCloudAgent = try await identus.createInvitation()
+                                    let invitationFromCloudAgent = try await Identus.shared.createInvitation()
                                     guard let invitationFromCloudAgent else { return }
-                                    try await identus.acceptDIDCommInvite(invitationFromCloudAgent: invitationFromCloudAgent)
+                                    try await Identus.shared.acceptDIDCommInvite(invitationFromCloudAgent: invitationFromCloudAgent)
                                 } catch {
                                     print(error)
                                 }
                             }
-                            print(identus.status)
+                            print(Identus.shared.status)
                             
-                            if identus.status == "running" {
+                            if Identus.shared.status == "running" {
                                 print("we should transition from LoadingScreen to Content")
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                                     viewState = .tabs


### PR DESCRIPTION
Moving Identus class to be a Singleton.  This may prove to be a convenience for users, or a silly nightmare.  TBD.  For now, it makes it easy to call from any ViewModel.  Maybe we should double back later and switch this back to a DI container.