### PR TITLE
Set proper schemaId on CredentialOffer 

### DIFF
--- a/FlightTix/FlightTix/Agent/IdentusConfig.swift
+++ b/FlightTix/FlightTix/Agent/IdentusConfig.swift
@@ -24,4 +24,5 @@ struct IdentusConfig {
     let cloudAgentIssuerDIDKeychainKey: String = "CloudAgentIssuerDID"
     
     let passportIssueVCThidKeychainKey: String = "IssuePassportVC"
+    let passportSchemaID: String = "https://identusbook.com/flighttix-passport-1.0.0"
 }

--- a/FlightTix/FlightTix/Agent/IdentusConfig.swift
+++ b/FlightTix/FlightTix/Agent/IdentusConfig.swift
@@ -24,5 +24,6 @@ struct IdentusConfig {
     let cloudAgentIssuerDIDKeychainKey: String = "CloudAgentIssuerDID"
     
     let passportIssueVCThidKeychainKey: String = "IssuePassportVC"
-    let passportSchemaID: String = "https://identusbook.com/flighttix-passport-1.0.0"
+    let passportSchemaId: String = "https://identusbook.com/flighttix-passport-1.0.0"
+    let passportSchemaIdKeychainKey: String = "PassportSchemaId"
 }

--- a/FlightTix/FlightTix/Networking/API+CloudAgent.swift
+++ b/FlightTix/FlightTix/Networking/API+CloudAgent.swift
@@ -219,6 +219,23 @@ extension APIClient {
                 throw error
             }
         }
+        
+        func getSchemaByGuid(guid: String) async throws -> IdentusSchema? {
+            
+            let url = URL(string: "\(baseURL)/schema-registry/schemas/\(guid)")!
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+          
+            do {
+                let response = try await api.handleRequest(request: request)
+                guard let data = try await api.dataFromResponse(urlResponse: response.response, data: response.data) else {
+                    return nil
+                }
+                return try JSONDecoder().decode(IdentusSchema.self, from: data)
+            } catch {
+                throw error
+            }
+        }
     }
     
     var cloudAgent: CloudAgent {

--- a/FlightTix/FlightTix/Networking/API+CloudAgent.swift
+++ b/FlightTix/FlightTix/Networking/API+CloudAgent.swift
@@ -196,6 +196,29 @@ extension APIClient {
                 throw error
             }
         }
+        
+        func createSchema(schema: IdentusSchema) async throws -> IdentusSchema? {
+            
+            let createSchemaBody = schema
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .withoutEscapingSlashes
+            guard let bodyData = try? encoder.encode(createSchemaBody) else { return nil }
+            
+            let url = URL(string: "\(baseURL)/schema-registry/schemas")!
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.httpBody = bodyData
+        
+            do {
+                let response = try await api.handleRequest(request: request)
+                guard let data = try await api.dataFromResponse(urlResponse: response.response, data: response.data) else {
+                    return nil
+                }
+                return try JSONDecoder().decode(IdentusSchema.self, from: data)
+            } catch {
+                throw error
+            }
+        }
     }
     
     var cloudAgent: CloudAgent {

--- a/FlightTix/FlightTix/Networking/API+CloudAgent.swift
+++ b/FlightTix/FlightTix/Networking/API+CloudAgent.swift
@@ -9,6 +9,8 @@ import Foundation
 
 extension APIClient {
     
+    final class CredentialOfferResponseDecodeError: Error {}
+    
     struct CloudAgent {
         
         var api: APIClient
@@ -72,7 +74,13 @@ extension APIClient {
                 guard let data = try await api.dataFromResponse(urlResponse: response.response, data: response.data) else {
                     return nil
                 }
-                return try JSONDecoder().decode(CreateCredentialOfferResponse.self, from: data)
+                do {
+                    let credentialOfferRresponse = try JSONDecoder().decode(CreateCredentialOfferResponse.self, from: data)
+                    return credentialOfferRresponse
+                } catch {
+                    throw CredentialOfferResponseDecodeError()
+                }
+                
             } catch {
                 throw error
             }

--- a/FlightTix/FlightTix/Networking/APIClient.swift
+++ b/FlightTix/FlightTix/Networking/APIClient.swift
@@ -32,7 +32,11 @@ actor APIClient {
     public func dataFromResponse(urlResponse: URLResponse, data: Data?) async throws -> Data? {
         guard let response = urlResponse as? HTTPURLResponse, (response.statusCode == 200 || response.statusCode == 201 || response.statusCode == 202) else {
             guard let response = urlResponse as? HTTPURLResponse, (response.statusCode == 400) else {
-                
+                    print("We got a 400")
+                guard let response = urlResponse as? HTTPURLResponse, (response.statusCode == 500) else {
+                    print("We got a 500")
+                    return nil
+                }
                 return nil
             }
             return nil

--- a/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
+++ b/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
@@ -1,0 +1,51 @@
+//
+//  IdentusSchema.swift
+//  FlightTix
+//
+//  Created by Jon Bauer on 1/18/25.
+//
+
+import Foundation
+
+struct IdentusSchema: Codable {
+    let name: String
+    let version: String
+    let description: String
+    let type: String
+    let author: String
+    let tags: [String]
+    let schema: Schema
+}
+
+struct Schema: Codable {
+    let id: String
+    let schema: String
+    let description: String
+    let type: String
+    let properties: Properties
+    let required: [String]
+    let additionalProperties: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id = "$id"
+        case schema = "$schema"
+        case description
+        case type
+        case properties
+        case required
+        case additionalProperties
+    }
+}
+
+struct Properties: Codable {
+    let name: PropertyDetails
+    let did: PropertyDetails
+    let dateOfIssuance: PropertyDetails
+    let passportNumber: PropertyDetails
+    let dob: PropertyDetails
+}
+
+struct PropertyDetails: Codable {
+    let type: String
+    let format: String?
+}

--- a/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
+++ b/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
@@ -40,7 +40,6 @@ struct Schema: Codable {
 
 struct Properties: Codable {
     let name: PropertyDetails
-    let did: PropertyDetails
     let dateOfIssuance: PropertyDetails
     let passportNumber: PropertyDetails
     let dob: PropertyDetails

--- a/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
+++ b/FlightTix/FlightTix/Networking/APIModels/IdentusSchema.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct IdentusSchema: Codable {
+    let guid: String?
     let name: String
     let version: String
     let description: String

--- a/FlightTix/FlightTix/Networking/APIModels/IssuerCredentialCredentialOffer.swift
+++ b/FlightTix/FlightTix/Networking/APIModels/IssuerCredentialCredentialOffer.swift
@@ -31,7 +31,7 @@ public struct CreateCredentialOfferResponse: Decodable, Sendable {
 
 public struct CreateCredentialOfferRequest: Encodable, Sendable {
     let validityPeriod: Int
-    //let schemaId: String
+    let schemaId: String
     //let credentialDefinitionId: String?
     let credentialFormat: String
     let claims: PassportClaimsRequest

--- a/FlightTix/FlightTix/RegisterViewModel.swift
+++ b/FlightTix/FlightTix/RegisterViewModel.swift
@@ -31,6 +31,8 @@ class RegisterViewModel: ObservableObject {
             guard let issuerDID = Identus.shared.readIssuerDIDFromKeychain() else { return }
             guard let shortFormIssuerDID = try await Identus.shared.didShortForm(from: issuerDID) else { return }
             guard try await Identus.shared.verifyIssuerDIDIsPublished(shortOrLongFormDID: shortFormIssuerDID.string) else { return }
+            // Get Passport SchemaId
+            guard let passportSchemaId = Identus.shared.readPassportSchemaIdFromKeychain() else { return }
             
             // Get ConnectionId
             guard let currentConnectionId = Identus.shared.readConnectionIdFromKeychain() else { return }
@@ -38,6 +40,7 @@ class RegisterViewModel: ObservableObject {
             do {
                 let credentialOffer = try await Identus.shared.createCredentialOffer(request: CreateCredentialOfferRequest(
                     validityPeriod: 3600,
+                    schemaId: "http://localhost/cloud-agent/schema-registry/schemas/\(passportSchemaId)/schema",
                     credentialFormat: "JWT",
                     claims: PassportClaimsRequest(name: passport.name,
                                                   dateOfIssuance: Date.now.iso8601String(),

--- a/FlightTix/FlightTix/RegisterViewModel.swift
+++ b/FlightTix/FlightTix/RegisterViewModel.swift
@@ -28,19 +28,28 @@ class RegisterViewModel: ObservableObject {
              */
             
             // Get IssuerDID and verify it's been published.
-            guard let issuerDID = Identus.shared.readIssuerDIDFromKeychain() else { return }
-            guard let shortFormIssuerDID = try await Identus.shared.didShortForm(from: issuerDID) else { return }
-            guard try await Identus.shared.verifyIssuerDIDIsPublished(shortOrLongFormDID: shortFormIssuerDID.string) else { return }
+            guard let issuerDID = Identus.shared.readIssuerDIDFromKeychain() else {
+                return
+            }
+            guard let shortFormIssuerDID = try await Identus.shared.didShortForm(from: issuerDID) else {
+                return
+            }
+            guard try await Identus.shared.verifyIssuerDIDIsPublished(shortOrLongFormDID: shortFormIssuerDID.string) else { return
+            }
             // Get Passport SchemaId
-            guard let passportSchemaId = Identus.shared.readPassportSchemaIdFromKeychain() else { return }
+            guard let passportSchemaId = Identus.shared.readPassportSchemaIdFromKeychain() else {
+                return
+            }
             
             // Get ConnectionId
-            guard let currentConnectionId = Identus.shared.readConnectionIdFromKeychain() else { return }
+            guard let currentConnectionId = Identus.shared.readConnectionIdFromKeychain() else {
+                return
+            }
 
             do {
                 let credentialOffer = try await Identus.shared.createCredentialOffer(request: CreateCredentialOfferRequest(
                     validityPeriod: 3600,
-                    schemaId: "http://localhost/cloud-agent/schema-registry/schemas/\(passportSchemaId)/schema",
+                    schemaId: "http://localhost:8085/schema-registry/schemas/\(passportSchemaId)/schema", // TODO: make this baseURL dynamic.  it's very important to be THIS baseURL, Cloud Agent can't dereference it from Docker if's different.  This should only be this way for dev.  Prod needs a real live URL
                     credentialFormat: "JWT",
                     claims: PassportClaimsRequest(name: passport.name,
                                                   dateOfIssuance: Date.now.iso8601String(),

--- a/FlightTix/FlightTix/Schemas/Passport-Schema-1.0.json
+++ b/FlightTix/FlightTix/Schemas/Passport-Schema-1.0.json
@@ -17,9 +17,6 @@
             "name": {
                 "type": "string"
             },
-            "did": {
-                "type": "string"
-            },
             "dateOfIssuance": {
                 "type": "string",
                 "format": "date-time"
@@ -34,7 +31,6 @@
         },
         "required": [
             "name",
-            "did",
             "dateOfIssuance",
             "passportNumber",
             "dob"

--- a/FlightTix/FlightTix/Schemas/Passport-Schema-1.0.json
+++ b/FlightTix/FlightTix/Schemas/Passport-Schema-1.0.json
@@ -1,0 +1,44 @@
+{
+    "name": "passport",
+    "version": "1.0.0",
+    "description": "Passport Schema",
+    "type": "https://w3c-ccg.github.io/vc-json-schemas/schema/2.0/schema.json",
+    "author": "REPLACE_WITH_AUTHOR_DID",
+    "tags": [
+        "passport",
+        "schema"
+    ],
+    "schema": {
+        "$id": "https://identusbook.com/flighttix-passport-1.0.0",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "Passport",
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "did": {
+                "type": "string"
+            },
+            "dateOfIssuance": {
+                "type": "string",
+                "format": "date-time"
+            },
+            "passportNumber": {
+                "type": "string"
+            },
+            "dob": {
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+        "required": [
+            "name",
+            "did",
+            "dateOfIssuance",
+            "passportNumber",
+            "dob"
+        ],
+        "additionalProperties": true
+    }
+}


### PR DESCRIPTION
Create Schema dynamically on start up.

We need to pass the correct `schemaId` in the CredentialOffer so that Docker can see the contents of our Schema.  This URL is different than what we use outside of Docker.

